### PR TITLE
Add 20-minute countdown timer section

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,38 @@
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Jost:100,200,300,400,500,600,700,800,900,100i,200i,300i,400i,500i,600i,700i,800i,900i&display=swap"></noscript>
   <link rel="preload" as="style" href="assets/mobirise/css/mbr-additional.css?v=RU6xws"><link rel="stylesheet" href="assets/mobirise/css/mbr-additional.css?v=RU6xws" type="text/css">
 
+  <style>
+    #countdown-section .timer-wrapper {
+      background: rgba(255, 255, 255, 0.85);
+      border-radius: 1rem;
+      padding: 2rem 1.5rem;
+      box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.1);
+    }
+
+    #countdown-section #timer-display {
+      font-weight: 600;
+      letter-spacing: 0.2rem;
+    }
+
+    #countdown-section .timer-controls .btn {
+      min-width: 140px;
+      margin-bottom: 0.5rem;
+    }
+
+    @media (max-width: 576px) {
+      #countdown-section .timer-controls {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      #countdown-section .timer-controls .btn {
+        width: 100%;
+        margin-right: 0 !important;
+      }
+    }
+  </style>
+
   
   
   
@@ -63,7 +95,7 @@
 
 <section data-bs-version="5.1" class="header14 cid-sFzxmVl7J6 mbr-fullscreen mbr-parallax-background" id="header14-1f">
 
-    
+
 
     <div class="mbr-overlay" style="opacity: 0.8; background-color: rgb(255, 255, 255);"></div>
 
@@ -76,7 +108,28 @@
                 <div class="text-wrapper">
                     <h1 class="mbr-section-title mbr-fonts-style mb-3 display-5"><strong>&nbsp;Clases de Computación: Sistema&nbsp; Operativo y Operaciones&nbsp;en Microsoft Word</strong></h1>
                     <p class="mbr-text mbr-fonts-style display-7">Este curso está diseñado especialmente para quienes desean adquirir habilidades básicas en computación y mejorar su desempeño personal, académico o laboral. A través de clases 100% en línea, prácticas y fáciles de seguir, aprenderás a utilizar correctamente el Sistema Operativo Windows y las herramientas fundamentales de Microsoft Word.<br><br>No necesitas tener experiencia previa. Te enseñaremos desde cómo encender y organizar tu equipo, hasta cómo crear, editar y presentar documentos profesionales. Nuestro enfoque está pensado para personas que buscan aprender a su ritmo, con apoyo continuo y materiales didácticos claros.<br><br><br></p>
-                    
+
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section data-bs-version="5.1" class="content1" id="countdown-section">
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-10 col-lg-8">
+                <div class="text-center py-5">
+                    <h2 class="mbr-section-title mbr-fonts-style mb-4 display-5"><strong>Temporizador de 20 minutos</strong></h2>
+                    <p class="mbr-text mbr-fonts-style display-7">Utiliza este temporizador para organizar tus sesiones de estudio o descansos. Puedes iniciarlo, pausarlo o reiniciarlo en cualquier momento.</p>
+                    <div class="timer-wrapper">
+                        <div id="timer-display" class="display-2 mbr-fonts-style">20:00</div>
+                        <div class="timer-controls mt-4">
+                            <button id="start-timer" class="btn btn-primary display-7 me-2">Iniciar</button>
+                            <button id="pause-timer" class="btn btn-secondary display-7 me-2">Pausar</button>
+                            <button id="reset-timer" class="btn btn-warning display-7">Reiniciar</button>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -587,7 +640,67 @@
             </div>
         </div>
     </div>
-</section><section class="display-7" style="padding: 0;align-items: center;justify-content: center;flex-wrap: wrap;    align-content: center;display: flex;position: relative;height: 4rem;"><a href="https://mobiri.se/3599840" style="flex: 1 1;height: 4rem;position: absolute;width: 100%;z-index: 1;"><img alt="" style="height: 4rem;" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="></a><p style="margin: 0;text-align: center;" class="display-7">&#8204;</p><a style="z-index:1" href="https://mobirise.com/builder/ai-website-generator.html">AI Website Generator</a></section><script src="assets/bootstrap/js/bootstrap.bundle.min.js"></script>  <script src="assets/parallax/jarallax.js"></script>  <script src="assets/smoothscroll/smooth-scroll.js"></script>  <script src="assets/ytplayer/index.js"></script>  <script src="assets/dropdown/js/navbar-dropdown.js"></script>  <script src="assets/sociallikes/social-likes.js"></script>  <script src="assets/theme/js/script.js"></script>  
+</section><section class="display-7" style="padding: 0;align-items: center;justify-content: center;flex-wrap: wrap;    align-content: center;display: flex;position: relative;height: 4rem;"><a href="https://mobiri.se/3599840" style="flex: 1 1;height: 4rem;position: absolute;width: 100%;z-index: 1;"><img alt="" style="height: 4rem;" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="></a><p style="margin: 0;text-align: center;" class="display-7">&#8204;</p><a style="z-index:1" href="https://mobirise.com/builder/ai-website-generator.html">AI Website Generator</a></section><script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const initialTime = 20 * 60;
+      let timeRemaining = initialTime;
+      let timerInterval = null;
+
+      const timerDisplay = document.getElementById('timer-display');
+      const startButton = document.getElementById('start-timer');
+      const pauseButton = document.getElementById('pause-timer');
+      const resetButton = document.getElementById('reset-timer');
+
+      const updateTimerDisplay = () => {
+        const minutes = String(Math.floor(timeRemaining / 60)).padStart(2, '0');
+        const seconds = String(timeRemaining % 60).padStart(2, '0');
+        timerDisplay.textContent = `${minutes}:${seconds}`;
+      };
+
+      const setRunningState = (isRunning) => {
+        startButton.disabled = isRunning;
+        pauseButton.disabled = !isRunning;
+      };
+
+      const pauseTimer = () => {
+        if (timerInterval !== null) {
+          clearInterval(timerInterval);
+          timerInterval = null;
+        }
+        setRunningState(false);
+      };
+
+      const startTimer = () => {
+        if (timerInterval !== null) {
+          return;
+        }
+        setRunningState(true);
+        timerInterval = setInterval(() => {
+          if (timeRemaining <= 0) {
+            pauseTimer();
+            timeRemaining = 0;
+            updateTimerDisplay();
+            return;
+          }
+          timeRemaining -= 1;
+          updateTimerDisplay();
+        }, 1000);
+      };
+
+      const resetTimer = () => {
+        pauseTimer();
+        timeRemaining = initialTime;
+        updateTimerDisplay();
+      };
+
+      startButton.addEventListener('click', startTimer);
+      pauseButton.addEventListener('click', pauseTimer);
+      resetButton.addEventListener('click', resetTimer);
+
+      updateTimerDisplay();
+      setRunningState(false);
+    });
+  </script><script src="assets/bootstrap/js/bootstrap.bundle.min.js"></script>  <script src="assets/parallax/jarallax.js"></script>  <script src="assets/smoothscroll/smooth-scroll.js"></script>  <script src="assets/ytplayer/index.js"></script>  <script src="assets/dropdown/js/navbar-dropdown.js"></script>  <script src="assets/sociallikes/social-likes.js"></script>  <script src="assets/theme/js/script.js"></script>
   
   
 </body>


### PR DESCRIPTION
## Summary
- add a dedicated section that highlights a reusable 20-minute study timer
- include styling and JavaScript to provide start, pause, and reset controls

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68c8c75ac2a883268f2e18841343d9c1